### PR TITLE
Updates ExecutableContent to use switch statement over elif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# You make your own .vscode
+.vscode/

--- a/CoreEngine/CoreEngine.csproj
+++ b/CoreEngine/CoreEngine.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>StateChartsDotNet.CoreEngine</AssemblyName>
     <RootNamespace>StateChartsDotNet.CoreEngine</RootNamespace>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoreEngine/Model/Execution/ExecutableContent.cs
+++ b/CoreEngine/Model/Execution/ExecutableContent.cs
@@ -49,7 +49,7 @@ namespace StateChartsDotNet.CoreEngine.Model.Execution
                     content = new Assign(assign);
                     break;
                 default:
-                    throw new InvalidCastException("CoreEngine.Execution is unable to cast Executable Metadata to correct type.");
+                    throw new ArgumentException(message: "Executable Metadata is not a recognized type", paramName: nameof(metadata));
             }
 
             Debug.Assert(content != null);

--- a/CoreEngine/Model/Execution/ExecutableContent.cs
+++ b/CoreEngine/Model/Execution/ExecutableContent.cs
@@ -22,37 +22,34 @@ namespace StateChartsDotNet.CoreEngine.Model.Execution
 
             ExecutableContent content = null;
 
-            if (metadata is IIfMetadata im)
+            switch (metadata)
             {
-                content = new If(im);
-            }
-            else if (metadata is IRaiseMetadata rm)
-            {
-                content = new Raise(rm);
-            }
-            else if (metadata is IScriptMetadata sm)
-            {
-                content = new Script(sm);
-            }
-            else if (metadata is IForeachMetadata fm)
-            {
-                content = new Foreach(fm);
-            }
-            else if (metadata is ILogMetadata lm)
-            {
-                content = new Log(lm);
-            }
-            else if (metadata is ISendMessageMetadata smd)
-            {
-                content = new SendMessage(smd);
-            }
-            else if (metadata is ICancelMetadata cm)
-            {
-                content = new Cancel(cm);
-            }
-            else if (metadata is IAssignMetadata am)
-            {
-                content = new Assign(am);
+                case IIfMetadata @if:
+                    content = new If(@if);
+                    break;
+                case IRaiseMetadata raise:
+                    content = new Raise(raise);
+                    break;
+                case IScriptMetadata script:
+                    content = new Script(script);
+                    break;
+                case IForeachMetadata @foreach:
+                    content = new Foreach(@foreach);
+                    break;
+                case ILogMetadata log:
+                    content = new Log(log);
+                    break;
+                case ISendMessageMetadata send:
+                    content = new SendMessage(send);
+                    break;
+                case ICancelMetadata cancel:
+                    content = new Cancel(cancel);
+                    break;
+                case IAssignMetadata assign:
+                    content = new Assign(assign);
+                    break;
+                default:
+                    throw new InvalidCastException("CoreEngine.Execution is unable to cast Executable Metadata to correct type.");
             }
 
             Debug.Assert(content != null);


### PR DESCRIPTION
Learning a bit about c# 9 so this change is not necessary, however it's interesting. Some even say switch statements, given it is ordered based on frequency, is faster than an elif block. 